### PR TITLE
feat(ci): add travis build with semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+env:
+  global:
+  - secure: yTWXodgyRx308b2IcSq+wl89LcuSTXXkoX1yJ9pFDbbbGeXsOAMBpeKtwuhdjfj+dNHgsNq5MHowuH3hkFjRolZYGjc+hfvmn1skriXGuyzcIL01U8nLJYfsBgjJ5K88HJTKPGktn3+SDQkWlfK1qTezR5O2lmXFa7hEUzFxV+YDCpICaFmIf7TGZk3g4knxt19NrqhiLA5P54u+qBhoKuA/iFpHjDpXrq9OdvJGc8mShA0gX0e/jip8T6otklJSdoCy3eHo5KDqC5AcXKyepaNL4fZubkg9w7fSb5Z0sTtg6+QfmQzUdeR5M++CDUnVUCAKySVC/PSN7Fbf+JTyVNezl6Ixtrv3LuR3XEXd7freq/tiUsdkrHJF69UApPdP9L53MhZY3hpulEnFYUuuECiD4H5L7seJIXHiDBdADfb6Dv15/WQn4YNwVgzZuP59SrGDV7xOsGqyNdPoEAEI8OcH5Cu1TJKy3AM29HkQt5PSb/DesgLwD/ngC9IN7a1/SV/LqovPl+r+WH4XRHonlPMe0a1sQuGdOSWWWQRXxHGGm0EqkbTn9RpD9IltaswPted5hNAaHXu2lMWgQ+Cn9l31B9yLI4Yxk+JQgQiHKqYVprGlADToSjQrMRR/k8YcRm9qYpey9R5pUQc4TEU7X6jWWFR4Br4cm8XO5aphXPY=
+  - secure: BB6wNTQrRkCtQRWyt5qNH8ybWIR8hKzKS4LDZ3VsjY+dypWMN7KgslTnb/9JDbvUFcifKs3je46SCmemHUVpCcThnyxaU1nIUsiaQ0bQuy57HoB5lblDU7MpAIr4LE8m7RE7RzkUAboTzrMCeAhFBjNzTBvfJVUrzvdLJWhmmKuRu3QQ1xTQ1QSLFEjiCf9e4eIfZYrp6VoUGKlRoZrUHr7T1ztj0h8WNtxFZnlOP/Nxq66UlexxiIYOV2BH2leqjgECjEzeDVaTg8+s6Xkr4bUN0XNbpCwIiZX3UYCIqYNUGxakYtzjVJWrfe+hq8chR7TrCNCqZzwdrqzd8e+IDO0ruRs0/2iT1yi1nZe7zLHALB9Q1kamxoi72FbabSoO5Hvgs7pnUm5FtZnz07QjWdkiIMSCJo90dYQrdxhtfML2x9WWV/SpScfrwj2lXFLwPukUP6vuLJ7UjqHwGPFKUWSMtn6NRmgXnItVJqIfSrlDLSqj2h+cetokpACzCN0AKaR7uVbn1WN0ITIK6Y+7qsi6+f9p+iLn9Nl3gWTRYrcHdHbkny8JI1g/Fc4T8m5AeQwP3yDu/Ms79K68uZqXi5O2FDsx/xpzT00s0fcx9cCShsKjkf3LFGhBOK8fUK+8yqKBduJAgy21ZdUi7x05hjQ06hljHHLows3pKsEZmFM=
+cache:
+  directories:
+  - "~/.npm"
+notifications:
+  email: false
+node_js:
+- stable
+os:
+- linux
+script:
+- node index.js
+after_success:
+- npm run semantic-release
+branches:
+  except:
+  - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/package.json
+++ b/package.json
@@ -57,11 +57,38 @@
     "eslint-plugin-opensphere": "^1.0.0"
   },
   "readme": "README.md",
-  "scripts": {},
-  "version": "1.0.1",
+  "scripts": {
+    "semantic-release": "semantic-release"
+  },
+  "release": {
+    "verifyConditions": [
+      "@semantic-release/condition-travis",
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/git"
+    ],
+    "getLastRelease": "@semantic-release/git",
+    "publish": [
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      {
+        "path": "@semantic-release/git",
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      },
+      "@semantic-release/github"
+    ]
+  },
   "devDependencies": {
+    "@semantic-release/changelog": "^1.0.0",
+    "@semantic-release/condition-travis": "^7.1.3",
+    "@semantic-release/git": "^2.0.1",
+    "@semantic-release/github": "^3.0.0",
+    "@semantic-release/npm": "^2.5.0",
     "cz-conventional-changelog": "^1.2.0",
     "husky": "^0.13.3",
+    "semantic-release": "^11.0.2",
     "validate-commit-msg": "^2.12.1"
-  }
+  },
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Add a simple travis build which checks the validity of the `index.js` file. Also added semantic-release script to automatically generate `CHANGELOG.md`, update version in `package.json`, publish to npm, and commit all that back in a `chore(release)` commit.