### PR TITLE
Adds exception for triple slash directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = {
     "space-unary-ops": "error",
 
     // enforce consistent spacing after the // or /* in a comment, and before the */
-    "spaced-comment": ["error", "always", { "block": { "balanced": true }}],
+    "spaced-comment": ["error", "always", { "line": { "markers": ["/"]}, "block": { "balanced": true}}],
 
     // require the jsdocs to be valid
     "valid-jsdoc": ["error", {


### PR DESCRIPTION
https://eslint.org/docs/rules/spaced-comment
https://docs.cypress.io/guides/tooling/intelligent-code-completion.html#Triple-slash-directives

Cypress tests use a triple slash directive.  Modified the rule to add a marker, so that these aren't flagged.