### PR TITLE
Adjustments to ESLint 6 upgrade changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,9 +100,17 @@ module.exports = {
       "CallExpression": {
         "arguments": 2
       },
+      "FunctionDeclaration": {
+        "parameters": 2
+      },
+      "FunctionExpression": {
+        "parameters": 2
+      },
       "MemberExpression": 2,
       "SwitchCase": 1,
-      "VariableDeclarator": 2
+      "VariableDeclarator": 2,
+      // allow ternary operators to be formatted at the developer's discretion
+      "ignoredNodes": ["ConditionalExpression"]
     }],
 
     // allow a maximum line length of 120

--- a/index.js
+++ b/index.js
@@ -201,11 +201,11 @@ module.exports = {
       "additionalTagNames": {
         "customTags": ["export", "final", "inheritDoc", "ngInject", "struct", "suppress"]
       },
-      // use "return" instead of "returns"
       "tagNamePreference": {
-        "returns": "return",
+        "augments": "extends",
         "class": "constructor",
-        "augments": "extends"
+        "constant": "const",
+        "returns": "return"
       },
       "preferredTypes": {
         "Boolean": "boolean",

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ module.exports = {
     "jsdoc/check-types": "error", // Recommended
     "jsdoc/implements-on-classes": "error", // Recommended
     "jsdoc/match-description": "off",
-    "jsdoc/newline-after-description": "error", // Recommended
+    "jsdoc/newline-after-description": "off", // Recommended
     "jsdoc/no-types": "off",
     // if this is enabled, all global namespaces (goog, ol, os, etc) must be defined in the config
     "jsdoc/no-undefined-types": "off", // Recommended
@@ -190,7 +190,6 @@ module.exports = {
     "jsdoc/require-param-description": "off", // Recommended
     "jsdoc/require-param-name": "error", // Recommended
     "jsdoc/require-param-type": "error", // Recommended
-    // only require a return if there is one in the function
     "jsdoc/require-returns": "error", // Recommended
     "jsdoc/require-returns-check": "error", // Recommended
     "jsdoc/require-returns-description": "off", // Recommended


### PR DESCRIPTION
* Function parameters are indented 2 levels. This was the behavior prior to the ESLint 6 upgrade, incurring fewer changes on projects wanting to upgrade. This is a breaking change for projects that have already upgraded.
* Ternary operators are ignored, because ESLint does not handle them well when used in variable assignment expressions.
* JSDoc `newline-after-description` has been disabled. This rule was intended for readability, but seems best left at the developer's discretion.
* Prefer `const` over `constant`. This was only flagging/changing constant functions, which we don't have in OpenSphere but was noticed in other projects.