### PR TITLE
feat(es6): use sourceType module to allow ES6 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = {
     "browser": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2018,
+    "sourceType": "module"
   },
   "rules": {
     //
@@ -40,6 +41,14 @@ module.exports = {
     "no-unsafe-finally": "error",
     "use-isnan": "error",
     "valid-typeof": "error",
+
+    //
+    // TODO: this rule applies only in strict mode, which is implied with "sourceType": "module". it should be enabled
+    // as a breaking change, as it will likely cause additional lint findings.
+    //
+    // https://eslint.org/docs/rules/no-invalid-this
+    //
+    "no-invalid-this": "off",
 
     // if this is enabled, all global namespaces (goog, ol, os, etc) must be defined in the config
     "no-undef": "off",


### PR DESCRIPTION
`"sourceType": "module"` enables the linter to process ES6 modules that use `import` and `export`. It will still work with files that are not modules, with the exception of the [`no-invalid-this`](https://eslint.org/docs/rules/no-invalid-this) rule. That rule is enabled by default with modules (because they imply `use strict`), and fails with Closure-style classes. Given it wasn't previously enabled, it has been explicitly disabled in this change.