### PR TITLE
feat: use no-unused-vars override to allow goog.requireType

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ module.exports = {
     "opensphere/requires-sorted": "error",
     "opensphere/single-module": "error",
 
+    // replace ESLint rule with opensphere's to ignore goog.requireType vars
+    "no-unused-vars": "off",
+    "opensphere/no-unused-vars": ["error", { "args": "none" }],
+
     // TODO: fix/remove checkTypes and uncomment this
     // "opensphere/no-suppress": ["error", ["checkTypes"]],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "eslint-config-google": "^0.13.0",
     "eslint-plugin-google-camelcase": "^0.0.2",
     "eslint-plugin-jsdoc": "^8.6.0",
-    "eslint-plugin-opensphere": "^2.2.0"
+    "eslint-plugin-opensphere": "^2.3.0"
   },
   "description": "ESLint config for opensphere",
   "directories": {},


### PR DESCRIPTION
Replace the default `no-unused-vars` rule from ESLint with the override in https://github.com/ngageoint/eslint-plugin-opensphere/pull/8.

To test:

- Check out this branch and the `eslint-plugin-opensphere` branch linked above.
- Remove the `// eslint-disable-line no-unused-vars` comment in `opensphere/src/os/alert/alertevent.js`. 
- With `goog.require`, you should get an error suggesting you use `goog.requireType`.
- With `goog.requireType` you should not get a lint error.
- Unused vars elsewhere in the code should still be reported as an error.