### PR TITLE
feat(jsdoc): remove valid-jsdoc and allow @type on functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,9 @@ module.exports = {
     // enforce consistent spacing after the // or /* in a comment, and before the */
     "spaced-comment": ["error", "always", { "line": { "markers": ["/"] }, "block": { "balanced": true } }],
 
+    // disable old, deprecated valid-jsdoc rule
+    "valid-jsdoc": "off",
+
     // Rules from jsdoc plugin
     "jsdoc/check-alignment": "error", // Recommended
     "jsdoc/check-examples": "off",
@@ -195,14 +198,14 @@ module.exports = {
     "jsdoc/require-example": "off",
     "jsdoc/require-hyphen-before-param-description": "off",
     "jsdoc/require-jsdoc": "error", // Recommended
-    "jsdoc/require-param": "error", // Recommended
+    "jsdoc/require-param": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/require-param-description": "off", // Recommended
-    "jsdoc/require-param-name": "error", // Recommended
-    "jsdoc/require-param-type": "error", // Recommended
-    "jsdoc/require-returns": "error", // Recommended
-    "jsdoc/require-returns-check": "error", // Recommended
+    "jsdoc/require-param-name": ["error", {"exemptedBy": ["type"]}], // Recommended
+    "jsdoc/require-param-type": ["error", {"exemptedBy": ["type"]}], // Recommended
+    "jsdoc/require-returns": ["error", {"exemptedBy": ["type"]}], // Recommended
+    "jsdoc/require-returns-check": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/require-returns-description": "off", // Recommended
-    "jsdoc/require-returns-type": "error", // Recommended
+    "jsdoc/require-returns-type": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/valid-types": "off" // Recommended
   },
   "settings": {


### PR DESCRIPTION
This does two things:
- Remove the old, deprecated `valid-jsdoc` rule inherited from the google config in favor of only running the new `jsdoc/*` rules from `eslint-plugin-jsdoc`. No sense in running both and running the old one also screws up the next item.
- Allow `@type` annotations on functions. Many function types are aliased as typedefs from OpenLayers, and this allows us to avoid copying around the entire parameter list to each function. Example:
```javascript
// typedef
/**
 * @typedef {function(ol.Coordinate, ol.Coordinate=, number=):ol.Coordinate}
 */
ol.TransformFunction;

// before
/**
 * @param {ol.Coordinate} coord
 * @param {ol.Coordinate=} opt_result
 * @param {number=} opt_length
 * @return {ol.Coordinate}
 */
package.someTransformImpl = function(coord, opt_result, opt_length) {};

// after
/**
 * @type {ol.TransformFunction}
 */
package.someTransformImpl = function(coord, opt_result, opt_length) {};
```
The "after" version there is optional (the "before" version will still pass the linter), but gives a much shorter option that doesn't involve copy/pasting those around so much.