### PR TITLE
fix: disable prefer-promise-reject-errors to allow shadowing Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,13 @@ module.exports = {
     // "block-scoped-var": "error",
     // "no-redeclare": "error",
 
+    //
+    // Allow rejecting promises with a string error message.
+    //
+    // Note: This was specifically disabled to allow shadowing the native Promise with:
+    //    const Promise = goog.require('goog.Promise');
+    //
+    "prefer-promise-reject-errors": "off",
 
     //
     // Custom rules from eslint-plugin-opensphere


### PR DESCRIPTION
When using the module syntax for `goog.require`, doing the following can trigger the disabled ESLint error:

```
const Promise = goog.require('goog.Promise');
```

ESLint considers `Promise` to be the native API, and requires passing an `Error` to `reject` calls. This is currently unwanted behavior, though we could consider making that change in the future.