### PR TITLE
feat(jsdoc): update eslint-config-jsdoc to latest, replace require-jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,8 @@ module.exports = {
     // enforce consistent spacing after the // or /* in a comment, and before the */
     "spaced-comment": ["error", "always", { "line": { "markers": ["/"] }, "block": { "balanced": true } }],
 
-    // disable old, deprecated valid-jsdoc rule
+    // disable old, deprecated jsdoc rules
+    "require-jsdoc": "off",
     "valid-jsdoc": "off",
 
     // Rules from jsdoc plugin
@@ -204,15 +205,21 @@ module.exports = {
     "jsdoc/require-description-complete-sentence": "off",
     "jsdoc/require-example": "off",
     "jsdoc/require-hyphen-before-param-description": "off",
-    "jsdoc/require-jsdoc": "error", // Recommended
+    "jsdoc/require-jsdoc": ["error", { // Recommended
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true,
+      },
+    }],
     "jsdoc/require-param": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/require-param-description": "off", // Recommended
-    "jsdoc/require-param-name": ["error", {"exemptedBy": ["type"]}], // Recommended
-    "jsdoc/require-param-type": ["error", {"exemptedBy": ["type"]}], // Recommended
+    "jsdoc/require-param-name": ["error"], // Recommended
+    "jsdoc/require-param-type": ["error"], // Recommended
     "jsdoc/require-returns": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/require-returns-check": ["error", {"exemptedBy": ["type"]}], // Recommended
     "jsdoc/require-returns-description": "off", // Recommended
-    "jsdoc/require-returns-type": ["error", {"exemptedBy": ["type"]}], // Recommended
+    "jsdoc/require-returns-type": ["error"], // Recommended
     "jsdoc/valid-types": "off" // Recommended
   },
   "settings": {
@@ -220,10 +227,12 @@ module.exports = {
       "additionalTagNames": {
         "customTags": ["export", "final", "inheritDoc", "ngInject", "struct", "suppress"]
       },
+      "mode": "closure",
       "tagNamePreference": {
         "augments": "extends",
         "class": "constructor",
         "constant": "const",
+        "file": "fileoverview",
         "returns": "return"
       },
       "preferredTypes": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "eslint-config-google": "^0.13.0",
     "eslint-plugin-google-camelcase": "^0.0.2",
-    "eslint-plugin-jsdoc": "^8.6.0",
+    "eslint-plugin-jsdoc": "^21.0.0",
     "eslint-plugin-opensphere": "^2.3.0"
   },
   "description": "ESLint config for opensphere",


### PR DESCRIPTION
BREAKING CHANGE: The update to eslint-config-jsdoc may find rule violations
that were previously missed. The most common occurrence seems to be with
check-alignment, which can be resolved by --fix.