### PR TITLE
fix(import): allow relative parent imports for module relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,10 @@ module.exports = {
     // Custom rules from eslint-plugin-import
     //
 
+    // Import paths relative to the module (ie, 'opensphere/src/path/to/module.js') will be treated as relative parent
+    // imports by eslint so this must be disabled.
+    "import/no-relative-parent-imports": "off",
+
     // Warn when importing something marked as @deprecated
     "import/no-deprecated": "warn",
 
@@ -86,8 +90,6 @@ module.exports = {
     "import/no-absolute-path": "error",
     // Do not allow relative paths to sibling projects (ie, '../some-project/src/index.js')
     "import/no-relative-packages": "error",
-    // Do not allow relative paths to parents (ie, use full module path instead of '../')
-    "import/no-relative-parent-imports": "error",
     // Do not allow a module to import itself
     "import/no-self-import": "error",
 


### PR DESCRIPTION
Internal import paths relative to a package (ie, `opensphere/src/os/os.js`) will be correctly recognized as relative parent imports when building OpenSphere by itself without a Yarn workspace. The workspace was fooling eslint by linking the project under `node_modules`, but eslint correctly errors when not using a workspace. This rule will be explicitly disabled and left to developers to determine the best import paths for their projects.