### PR TITLE
feat: enforce esm import format

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,21 @@ module.exports = {
     "import/no-relative-packages": "error",
     // Do not allow a module to import itself
     "import/no-self-import": "error",
+    // All imports must be resolveable
+    "import/no-unresolved": ["error", {
+      "caseSensitiveStrict": true
+    }],
+    // Use shortest path
+    "import/no-useless-path-segments": "error",
+    "import/no-duplicates": "error",
+    // Force extensions for import files
+    "import/extensions": ["error", {
+      "js": "always",
+      "json": "always",
+      "ts": "always"
+    }],
+    // No destructure for import of default exports
+    "import/no-named-default": "error",
 
     //
     // Enforce ordering of imports:


### PR DESCRIPTION
BREAKING CHANGE: File extensions are required for import statements,
defaults are not allowed to be destructured,
and all imports must be resolvable